### PR TITLE
DM-12: User Searches For Plants

### DIFF
--- a/backend/src/main/java/tqs/estore/backend/controllers/CategoryController.java
+++ b/backend/src/main/java/tqs/estore/backend/controllers/CategoryController.java
@@ -1,5 +1,6 @@
 package tqs.estore.backend.controllers;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +23,7 @@ public class CategoryController {
 
     @GetMapping("/all")
     public ResponseEntity<List<PlantCategory>> getAllCategories(){
-        return null;
+        return new ResponseEntity<>(categoryService.getAllCategories(), HttpStatus.OK);
     }
 
 }

--- a/backend/src/main/java/tqs/estore/backend/controllers/PlantController.java
+++ b/backend/src/main/java/tqs/estore/backend/controllers/PlantController.java
@@ -1,10 +1,8 @@
 package tqs.estore.backend.controllers;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import tqs.estore.backend.datamodel.Plant;
 import tqs.estore.backend.services.PlantService;
 
@@ -23,22 +21,22 @@ public class PlantController {
 
     @GetMapping("/all")
     public ResponseEntity<List<Plant>> getAllPlants(){
-        return null;
+        return new ResponseEntity<>(plantService.getAllPlants(), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Plant> getPlantById(Long id){
+    public ResponseEntity<Plant> getPlantById(@PathVariable Long id){
         return null;
     }
 
     @GetMapping("/name/{name}")
-    public ResponseEntity<List<Plant>> getPlantsByName(String name){
-        return null;
+    public ResponseEntity<List<Plant>> getPlantsByName(@PathVariable String name){
+        return new ResponseEntity<>(plantService.getPlantsByName(name), HttpStatus.OK);
     }
 
     @GetMapping("/category/{category}")
-    public ResponseEntity<List<Plant>> getPlantsByCategory(String category){
-        return null;
+    public ResponseEntity<List<Plant>> getPlantsByCategory(@PathVariable String category){
+        return new ResponseEntity<>(plantService.getPlantsByCategory(category), HttpStatus.OK);
     }
 
 

--- a/backend/src/main/java/tqs/estore/backend/controllers/PlantController.java
+++ b/backend/src/main/java/tqs/estore/backend/controllers/PlantController.java
@@ -34,9 +34,9 @@ public class PlantController {
         return new ResponseEntity<>(plantService.getPlantsByName(name), HttpStatus.OK);
     }
 
-    @GetMapping("/category/{category}")
-    public ResponseEntity<List<Plant>> getPlantsByCategory(@PathVariable String category){
-        return new ResponseEntity<>(plantService.getPlantsByCategory(category), HttpStatus.OK);
+    @GetMapping("/category/{categoryID}")
+    public ResponseEntity<List<Plant>> getPlantsByCategory(@PathVariable Integer categoryID){
+        return new ResponseEntity<>(plantService.getPlantsByCategory(categoryID), HttpStatus.OK);
     }
 
 

--- a/backend/src/main/java/tqs/estore/backend/datamodel/Plant.java
+++ b/backend/src/main/java/tqs/estore/backend/datamodel/Plant.java
@@ -29,7 +29,7 @@ public class Plant {
     @Column(nullable = false)
     private String description;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "categoryId", nullable = false)
     private PlantCategory category;
 }

--- a/backend/src/main/java/tqs/estore/backend/repositories/PlantRepository.java
+++ b/backend/src/main/java/tqs/estore/backend/repositories/PlantRepository.java
@@ -1,4 +1,10 @@
 package tqs.estore.backend.repositories;
 import org.springframework.data.jpa.repository.JpaRepository;
 import tqs.estore.backend.datamodel.Plant;
-public interface PlantRepository extends JpaRepository<Plant, Long> { }
+import java.util.List;
+public interface PlantRepository extends JpaRepository<Plant, Long> {
+    List<Plant> findByNameContaining(String name);
+
+    List<Plant> findByCategoryCategoryId(Long categoryId);
+
+}

--- a/backend/src/main/java/tqs/estore/backend/services/CategoryService.java
+++ b/backend/src/main/java/tqs/estore/backend/services/CategoryService.java
@@ -1,6 +1,4 @@
 package tqs.estore.backend.services;
-
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import tqs.estore.backend.datamodel.PlantCategory;
 import tqs.estore.backend.repositories.CategoryRepository;
@@ -14,7 +12,7 @@ public class CategoryService {
     public CategoryService(CategoryRepository categoryRepository){
         this.categoryRepository = categoryRepository;
     }
-    public ResponseEntity<List<PlantCategory>> getAllCategories(){
+    public List<PlantCategory> getAllCategories(){
         return null;
     }
 }

--- a/backend/src/main/java/tqs/estore/backend/services/CategoryService.java
+++ b/backend/src/main/java/tqs/estore/backend/services/CategoryService.java
@@ -13,6 +13,6 @@ public class CategoryService {
         this.categoryRepository = categoryRepository;
     }
     public List<PlantCategory> getAllCategories(){
-        return null;
+        return categoryRepository.findAll();
     }
 }

--- a/backend/src/main/java/tqs/estore/backend/services/CategoryService.java
+++ b/backend/src/main/java/tqs/estore/backend/services/CategoryService.java
@@ -12,6 +12,12 @@ public class CategoryService {
     public CategoryService(CategoryRepository categoryRepository){
         this.categoryRepository = categoryRepository;
     }
+
+
+    /**
+     * Get all categories from floralfiesta database
+     * @return List of categories
+     */
     public List<PlantCategory> getAllCategories(){
         return categoryRepository.findAll();
     }

--- a/backend/src/main/java/tqs/estore/backend/services/PlantService.java
+++ b/backend/src/main/java/tqs/estore/backend/services/PlantService.java
@@ -14,6 +14,10 @@ public class PlantService {
         this.plantRepository = plantRepository;
     }
 
+    /**
+     * Get all plants from floralfiesta database
+     * @return List of plants
+     */
     public List<Plant> getAllPlants(){
         return plantRepository.findAll();
     }
@@ -22,10 +26,21 @@ public class PlantService {
         return null;
     }
 
+    /**
+     * Get plants from floralfiesta database by name
+     * @param name - name of the plant
+     * @return List of plants
+     */
+
     public List<Plant> getPlantsByName(String name){
         return plantRepository.findByNameContaining(name);
     }
 
+    /**
+     * Get plants from floralfiesta database by category
+     * @param categoryID - id of the category
+     * @return List of plants
+     */
     public List<Plant> getPlantsByCategory(Integer categoryID){
         return plantRepository.findByCategoryCategoryId(categoryID.longValue());
     }

--- a/backend/src/main/java/tqs/estore/backend/services/PlantService.java
+++ b/backend/src/main/java/tqs/estore/backend/services/PlantService.java
@@ -27,7 +27,7 @@ public class PlantService {
         return null;
     }
 
-    public List<Plant> getPlantsByCategory(String category){
+    public List<Plant> getPlantsByCategory(Integer categoryID){
         return null;
     }
 

--- a/backend/src/main/java/tqs/estore/backend/services/PlantService.java
+++ b/backend/src/main/java/tqs/estore/backend/services/PlantService.java
@@ -15,19 +15,19 @@ public class PlantService {
         this.plantRepository = plantRepository;
     }
 
-    public ResponseEntity<List<Plant>> getAllPlants(){
+    public List<Plant> getAllPlants(){
         return null;
     }
 
-    public ResponseEntity<Plant> getPlantById(Long id){
+    public Plant getPlantById(Long id){
         return null;
     }
 
-    public ResponseEntity<List<Plant>> getPlantsByName(String name){
+    public List<Plant> getPlantsByName(String name){
         return null;
     }
 
-    public ResponseEntity<List<Plant>> getPlantsByCategory(String category){
+    public List<Plant> getPlantsByCategory(String category){
         return null;
     }
 

--- a/backend/src/main/java/tqs/estore/backend/services/PlantService.java
+++ b/backend/src/main/java/tqs/estore/backend/services/PlantService.java
@@ -1,6 +1,5 @@
 package tqs.estore.backend.services;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import tqs.estore.backend.datamodel.Plant;
 import tqs.estore.backend.repositories.PlantRepository;
@@ -16,7 +15,7 @@ public class PlantService {
     }
 
     public List<Plant> getAllPlants(){
-        return null;
+        return plantRepository.findAll();
     }
 
     public Plant getPlantById(Long id){
@@ -24,11 +23,11 @@ public class PlantService {
     }
 
     public List<Plant> getPlantsByName(String name){
-        return null;
+        return plantRepository.findByNameContaining(name);
     }
 
     public List<Plant> getPlantsByCategory(Integer categoryID){
-        return null;
+        return plantRepository.findByCategoryCategoryId(categoryID.longValue());
     }
 
 }

--- a/backend/src/test/java/tqs/estore/backend/boundaryTests/CategoryController_withMockServiceTest.java
+++ b/backend/src/test/java/tqs/estore/backend/boundaryTests/CategoryController_withMockServiceTest.java
@@ -1,0 +1,80 @@
+package tqs.estore.backend.boundaryTests;
+
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tqs.estore.backend.controllers.CategoryController;
+import tqs.estore.backend.services.CategoryService;
+import tqs.estore.backend.datamodel.PlantCategory;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CategoryController.class)
+public class CategoryController_withMockServiceTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CategoryService categoryService;
+
+    private List<PlantCategory> categories;
+
+    @BeforeEach
+    public void setUp() {
+        PlantCategory plantCategory = new PlantCategory();
+        plantCategory.setCategoryId(1L);
+        plantCategory.setName("Orchid");
+        plantCategory.setPhoto("orchid.jpg");
+
+        PlantCategory plantCategory2 = new PlantCategory();
+        plantCategory2.setCategoryId(2L);
+        plantCategory2.setName("Tulip");
+        plantCategory2.setPhoto("tulip.jpg");
+
+        categories = List.of(plantCategory, plantCategory2);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        categories = null;
+    }
+
+    @Test
+    public void whenGetAllCategories_thenReturnCategories_andStatus200() throws Exception {
+        when(categoryService.getAllCategories()).thenReturn(categories);
+        mockMvc.perform(get("/floralfiesta/category/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].categoryId").value(categories.get(0).getCategoryId()))
+                .andExpect(jsonPath("$[0].name").value(categories.get(0).getName()))
+                .andExpect(jsonPath("$[0].photo").value(categories.get(0).getPhoto()))
+                .andExpect(jsonPath("$[1].categoryId").value(categories.get(1).getCategoryId()))
+                .andExpect(jsonPath("$[1].name").value(categories.get(1).getName()))
+                .andExpect(jsonPath("$[1].photo").value(categories.get(1).getPhoto()));
+
+        verify(categoryService, times(1)).getAllCategories();
+    }
+
+    @Test
+    public void whenGetAllCategories_thenReturnEmptyList_andStatus200() throws Exception {
+        when(categoryService.getAllCategories()).thenReturn(List.of());
+        mockMvc.perform(get("/floralfiesta/category/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+
+        verify(categoryService, times(1)).getAllCategories();
+    }
+
+}

--- a/backend/src/test/java/tqs/estore/backend/boundaryTests/PlantController_withMockServiceTest.java
+++ b/backend/src/test/java/tqs/estore/backend/boundaryTests/PlantController_withMockServiceTest.java
@@ -1,0 +1,181 @@
+package tqs.estore.backend.boundaryTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tqs.estore.backend.controllers.PlantController;
+import tqs.estore.backend.datamodel.PlantCategory;
+import tqs.estore.backend.services.PlantService;
+
+import java.util.ArrayList;
+import java.util.List;
+import tqs.estore.backend.datamodel.Plant;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PlantController.class)
+public class PlantController_withMockServiceTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PlantService plantService;
+
+    private List<Plant> plants;
+    private List<Plant> plantsByName;
+
+    @BeforeEach
+    public void setUp() {
+        PlantCategory plantCategory = new PlantCategory();
+        plantCategory.setCategoryId(1L);
+        plantCategory.setName("Orchid");
+        plantCategory.setPhoto("orchid.jpg");
+
+        PlantCategory plantCategory2 = new PlantCategory();
+        plantCategory2.setCategoryId(2L);
+        plantCategory2.setName("Tulip");
+        plantCategory2.setPhoto("tulip.jpg");
+
+        plants = new ArrayList<>();
+        Plant plant1 = new Plant();
+        plant1.setName("Orchid");
+        plant1.setPrice(12.0);
+        plant1.setPhoto("orchid.jpg");
+        plant1.setDescription("Orchid is a plant that is very beautiful.");
+        plant1.setCategory(plantCategory);
+
+        Plant plant2 = new Plant();
+        plant2.setName("Tulip");
+        plant2.setPrice(5.0);
+        plant2.setPhoto("tulip.jpg");
+        plant2.setDescription("Tulip is a plant that makes people happy.");
+        plant2.setCategory(plantCategory2);
+
+        Plant plant3 = new Plant();
+        plant3.setName("Spice Orchid");
+        plant3.setPrice(20.0);
+        plant3.setPhoto("spice_orchid.jpg");
+        plant3.setDescription("Spice Orchid is from the Orchid family.");
+        plant3.setCategory(plantCategory);
+
+
+        plants.add(plant1);
+        plants.add(plant2);
+        plants.add(plant3);
+
+        plantsByName = new ArrayList<>();
+        plantsByName.add(plant1);
+        plantsByName.add(plant3);
+
+    }
+
+    @AfterEach
+    public void tearDown() {
+        plants = null;
+    }
+
+    @Test
+    public void whenGetAllPlants_thenReturnPlants_andStatus200() throws Exception {
+        when(plantService.getAllPlants()).thenReturn(plants);
+
+        mockMvc.perform(get("/floralfiesta/plant/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(3)))
+                .andExpect(jsonPath("$[0].name").value(plants.get(0).getName()))
+                .andExpect(jsonPath("$[0].price").value(plants.get(0).getPrice()))
+                .andExpect(jsonPath("$[0].photo").value(plants.get(0).getPhoto()))
+                .andExpect(jsonPath("$[0].description").value(plants.get(0).getDescription()))
+                .andExpect(jsonPath("$[0].category.name").value(plants.get(0).getCategory().getName()))
+                .andExpect(jsonPath("$[1].name").value(plants.get(1).getName()))
+                .andExpect(jsonPath("$[1].price").value(plants.get(1).getPrice()))
+                .andExpect(jsonPath("$[1].photo").value(plants.get(1).getPhoto()))
+                .andExpect(jsonPath("$[1].description").value(plants.get(1).getDescription()))
+                .andExpect(jsonPath("$[1].category.name").value(plants.get(1).getCategory().getName()))
+                .andExpect(jsonPath("$[2].name").value(plants.get(2).getName()))
+                .andExpect(jsonPath("$[2].price").value(plants.get(2).getPrice()))
+                .andExpect(jsonPath("$[2].photo").value(plants.get(2).getPhoto()))
+                .andExpect(jsonPath("$[2].description").value(plants.get(2).getDescription()))
+                .andExpect(jsonPath("$[2].category.name").value(plants.get(2).getCategory().getName()));
+
+
+        verify(plantService, times(1)).getAllPlants();
+    }
+
+    @Test
+    public void whenGetAllPlants_thenReturnEmptyList_andStatus200() throws Exception {
+        when(plantService.getAllPlants()).thenReturn(new ArrayList<>());
+
+        mockMvc.perform(get("/floralfiesta/plant/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+
+        verify(plantService, times(1)).getAllPlants();
+    }
+
+    @Test
+    public void whenGetPlantsByName_thenReturnPlants_andStatus200() throws Exception {
+        when(plantService.getPlantsByName("Orchid")).thenReturn(plantsByName);
+
+        mockMvc.perform(get("/floralfiesta/plant/name/Orchid"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].name").value(plantsByName.get(0).getName()))
+                .andExpect(jsonPath("$[0].price").value(plantsByName.get(0).getPrice()))
+                .andExpect(jsonPath("$[0].photo").value(plantsByName.get(0).getPhoto()))
+                .andExpect(jsonPath("$[0].description").value(plantsByName.get(0).getDescription()))
+                .andExpect(jsonPath("$[1].name").value(plantsByName.get(1).getName()))
+                .andExpect(jsonPath("$[1].price").value(plantsByName.get(1).getPrice()))
+                .andExpect(jsonPath("$[1].photo").value(plantsByName.get(1).getPhoto()))
+                .andExpect(jsonPath("$[1].description").value(plantsByName.get(1).getDescription()));
+
+        verify(plantService, times(1)).getPlantsByName("Orchid");
+    }
+
+    @Test
+    public void whenGetPlantsByName_thenReturnEmptyList_andStatus200() throws Exception {
+        when(plantService.getPlantsByName("Violet")).thenReturn(new ArrayList<>());
+
+        mockMvc.perform(get("/floralfiesta/plant/name/Violet"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+
+        verify(plantService, times(1)).getPlantsByName("Orchid");
+    }
+
+    @Test
+    public void whenGetPlantsByCategory_thenReturnPlants_andStatus200() throws Exception {
+        when(plantService.getPlantsByCategory("Orchid")).thenReturn(plantsByName);
+
+        mockMvc.perform(get("/floralfiesta/plant/category/Orchid"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].name").value(plantsByName.get(0).getName()))
+                .andExpect(jsonPath("$[0].price").value(plantsByName.get(0).getPrice()))
+                .andExpect(jsonPath("$[0].photo").value(plantsByName.get(0).getPhoto()))
+                .andExpect(jsonPath("$[0].description").value(plantsByName.get(0).getDescription()))
+                .andExpect(jsonPath("$[1].name").value(plantsByName.get(1).getName()))
+                .andExpect(jsonPath("$[1].price").value(plantsByName.get(1).getPrice()))
+                .andExpect(jsonPath("$[1].photo").value(plantsByName.get(1).getPhoto()))
+                .andExpect(jsonPath("$[1].description").value(plantsByName.get(1).getDescription()));
+
+        verify(plantService, times(1)).getPlantsByCategory("Orchid");
+    }
+
+    @Test
+    public void whenGetPlantsByCategory_thenReturnEmptyList_andStatus200() throws Exception {
+        when(plantService.getPlantsByCategory("Violet")).thenReturn(new ArrayList<>());
+
+        mockMvc.perform(get("/floralfiesta/plant/category/Violet"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+
+        verify(plantService, times(1)).getPlantsByCategory("Orchid");
+    }
+}

--- a/backend/src/test/java/tqs/estore/backend/boundaryTests/PlantController_withMockServiceTest.java
+++ b/backend/src/test/java/tqs/estore/backend/boundaryTests/PlantController_withMockServiceTest.java
@@ -146,7 +146,7 @@ public class PlantController_withMockServiceTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(0)));
 
-        verify(plantService, times(1)).getPlantsByName("Orchid");
+        verify(plantService, times(1)).getPlantsByName("Violet");
     }
 
     @Test
@@ -176,6 +176,6 @@ public class PlantController_withMockServiceTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(0)));
 
-        verify(plantService, times(1)).getPlantsByCategory("Orchid");
+        verify(plantService, times(1)).getPlantsByCategory("Violet");
     }
 }

--- a/backend/src/test/java/tqs/estore/backend/boundaryTests/PlantController_withMockServiceTest.java
+++ b/backend/src/test/java/tqs/estore/backend/boundaryTests/PlantController_withMockServiceTest.java
@@ -79,6 +79,7 @@ public class PlantController_withMockServiceTest {
     @AfterEach
     public void tearDown() {
         plants = null;
+        plantsByName = null;
     }
 
     @Test
@@ -151,9 +152,9 @@ public class PlantController_withMockServiceTest {
 
     @Test
     public void whenGetPlantsByCategory_thenReturnPlants_andStatus200() throws Exception {
-        when(plantService.getPlantsByCategory("Orchid")).thenReturn(plantsByName);
+        when(plantService.getPlantsByCategory(1)).thenReturn(plantsByName);
 
-        mockMvc.perform(get("/floralfiesta/plant/category/Orchid"))
+        mockMvc.perform(get("/floralfiesta/plant/category/1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(2)))
                 .andExpect(jsonPath("$[0].name").value(plantsByName.get(0).getName()))
@@ -165,17 +166,17 @@ public class PlantController_withMockServiceTest {
                 .andExpect(jsonPath("$[1].photo").value(plantsByName.get(1).getPhoto()))
                 .andExpect(jsonPath("$[1].description").value(plantsByName.get(1).getDescription()));
 
-        verify(plantService, times(1)).getPlantsByCategory("Orchid");
+        verify(plantService, times(1)).getPlantsByCategory(1);
     }
 
     @Test
     public void whenGetPlantsByCategory_thenReturnEmptyList_andStatus200() throws Exception {
-        when(plantService.getPlantsByCategory("Violet")).thenReturn(new ArrayList<>());
+        when(plantService.getPlantsByCategory(3)).thenReturn(new ArrayList<>());
 
-        mockMvc.perform(get("/floralfiesta/plant/category/Violet"))
+        mockMvc.perform(get("/floralfiesta/plant/category/3"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(0)));
 
-        verify(plantService, times(1)).getPlantsByCategory("Violet");
+        verify(plantService, times(1)).getPlantsByCategory(3);
     }
 }

--- a/backend/src/test/java/tqs/estore/backend/integrationTests/CategoryControllerIT.java
+++ b/backend/src/test/java/tqs/estore/backend/integrationTests/CategoryControllerIT.java
@@ -1,0 +1,89 @@
+package tqs.estore.backend.integrationTests;
+
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import tqs.estore.backend.datamodel.PlantCategory;
+import tqs.estore.backend.repositories.CategoryRepository;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@TestPropertySource(properties = {"spring.jpa.hibernate.ddl-auto=create-drop"})
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class CategoryControllerIT {
+
+    private final String BASE_URL = "http://localhost:";
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Container
+    private static final MySQLContainer mySQLContainer = new MySQLContainer("mysql:latest")
+            .withUsername("springuser")
+            .withPassword("password")
+            .withDatabaseName("db");
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mySQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.password", mySQLContainer::getPassword);
+        registry.add("spring.datasource.username", mySQLContainer::getUsername);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        PlantCategory plantCategory = new PlantCategory();
+        plantCategory.setName("Orchid");
+        plantCategory.setPhoto("orchid.jpg");
+
+        PlantCategory plantCategory2 = new PlantCategory();
+        plantCategory2.setName("Tulip");
+        plantCategory2.setPhoto("tulip.jpg");
+
+        categoryRepository.saveAndFlush(plantCategory);
+        categoryRepository.saveAndFlush(plantCategory2);
+    }
+
+    @AfterEach
+    public void resetDB(){
+        categoryRepository.deleteAll();
+    }
+
+    @Test
+    public void whenGetAllCategories_thenReturnCategories_andStatus200() {
+        RestAssured.get(BASE_URL + port + "/floralfiesta/category/all")
+                .then()
+                .statusCode(200)
+                .body("size()", is(2))
+                .body("[0].name", equalTo("Orchid"))
+                .body("[0].photo", equalTo("orchid.jpg"))
+                .body("[1].name", equalTo("Tulip"))
+                .body("[1].photo", equalTo("tulip.jpg"));
+    }
+
+    @Test
+    public void whenGetAllCategories_thenReturnEmptyList_andStatus200() {
+        categoryRepository.deleteAll();
+
+        RestAssured.get(BASE_URL + port + "/floralfiesta/category/all")
+                .then()
+                .statusCode(200)
+                .body("size()", is(0));
+    }
+
+}

--- a/backend/src/test/java/tqs/estore/backend/integrationTests/PlantControllerIT.java
+++ b/backend/src/test/java/tqs/estore/backend/integrationTests/PlantControllerIT.java
@@ -1,0 +1,195 @@
+package tqs.estore.backend.integrationTests;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import tqs.estore.backend.datamodel.Plant;
+import tqs.estore.backend.datamodel.PlantCategory;
+import tqs.estore.backend.repositories.CategoryRepository;
+import tqs.estore.backend.repositories.PlantRepository;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@TestPropertySource(properties = {"spring.jpa.hibernate.ddl-auto=create-drop"})
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class PlantControllerIT {
+
+    private final String BASE_URL = "http://localhost:";
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private PlantRepository plantRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+
+    private PlantCategory plantCategory;
+
+    @Container
+    private static final MySQLContainer mySQLContainer = new MySQLContainer("mysql:latest")
+            .withUsername("springuser")
+            .withPassword("password")
+            .withDatabaseName("db");
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mySQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.password", mySQLContainer::getPassword);
+        registry.add("spring.datasource.username", mySQLContainer::getUsername);
+    }
+
+    @BeforeEach
+    public void setUp(){
+        plantCategory = new PlantCategory();
+        plantCategory.setName("Orchid");
+        plantCategory.setPhoto("orchid.jpg");
+
+        PlantCategory plantCategory2 = new PlantCategory();
+        plantCategory2.setName("Tulip");
+        plantCategory2.setPhoto("tulip.jpg");
+
+        plantCategory = categoryRepository.saveAndFlush(plantCategory);
+        plantCategory2 = categoryRepository.saveAndFlush(plantCategory2);
+
+        Plant plant1 = new Plant();
+        plant1.setName("Orchid");
+        plant1.setPrice(12.0);
+        plant1.setPhoto("orchid.jpg");
+        plant1.setDescription("Orchid is a plant that is very beautiful.");
+        plant1.setCategory(plantCategory);
+
+
+        Plant plant2 = new Plant();
+        plant2.setName("Tulip");
+        plant2.setPrice(5.0);
+        plant2.setPhoto("tulip.jpg");
+        plant2.setDescription("Tulip is a plant that makes people happy.");
+        plant2.setCategory(plantCategory2);
+
+        Plant plant3 = new Plant();
+        plant3.setName("Spice Orchid");
+        plant3.setPrice(20.0);
+        plant3.setPhoto("spice_orchid.jpg");
+        plant3.setDescription("Spice Orchid is from the Orchid family.");
+        plant3.setCategory(plantCategory);
+
+        plantRepository.saveAndFlush(plant1);
+        plantRepository.saveAndFlush(plant2);
+        plantRepository.saveAndFlush(plant3);
+
+    }
+
+    @AfterEach
+    public void resetDB(){
+        plantRepository.deleteAll();
+        categoryRepository.deleteAll();
+    }
+
+
+
+
+    @Test
+    public void whenGetAllPlants_thenReturnPlants_andStatus200(){
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URL + port + "/floralfiesta/plant/all")
+                .then().statusCode(200)
+                .body("size()", is(3)).and()
+                .body("[0].name", equalTo("Orchid")).and()
+                .body("[0].price", equalTo(12.0f)).and()
+                .body("[0].photo", equalTo("orchid.jpg")).and()
+                .body("[0].description", equalTo("Orchid is a plant that is very beautiful.")).and()
+                .body("[0].category.name", equalTo("Orchid")).and()
+                .body("[0].category.photo", equalTo("orchid.jpg")).and()
+                .body("[1].name", equalTo("Tulip")).and()
+                .body("[1].price", equalTo(5.0f)).and()
+                .body("[1].photo", equalTo("tulip.jpg")).and()
+                .body("[1].description", equalTo("Tulip is a plant that makes people happy.")).and()
+                .body("[1].category.name", equalTo("Tulip")).and()
+                .body("[1].category.photo", equalTo("tulip.jpg")).and()
+                .body("[2].name", equalTo("Spice Orchid")).and()
+                .body("[2].price", equalTo(20.0f)).and()
+                .body("[2].photo", equalTo("spice_orchid.jpg")).and()
+                .body("[2].description", equalTo("Spice Orchid is from the Orchid family.")).and()
+                .body("[2].category.name", equalTo("Orchid")).and()
+                .body("[2].category.photo", equalTo("orchid.jpg"));
+    }
+
+    @Test
+    public void whenGetAllPlants_thenReturnsEmptyList_andStatus200(){
+        plantRepository.deleteAll();
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URL + port + "/floralfiesta/plant/all")
+                .then().statusCode(200)
+                .body("size()", is(0));
+    }
+
+    @Test
+    public void whenGetPlantsByName_thenReturnPlants_andStatus200() {
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URL + port + "/floralfiesta/plant/name/Orchid")
+                .then().statusCode(200)
+                .body("size()", is(2)).and()
+                .body("[0].name", equalTo("Orchid")).and()
+                .body("[0].price", equalTo(12.0f)).and()
+                .body("[0].photo", equalTo("orchid.jpg")).and()
+                .body("[0].description", equalTo("Orchid is a plant that is very beautiful.")).and()
+                .body("[0].category.name", equalTo("Orchid")).and()
+                .body("[0].category.photo", equalTo("orchid.jpg")).and()
+                .body("[1].name", equalTo("Spice Orchid")).and()
+                .body("[1].price", equalTo(20.0f)).and()
+                .body("[1].photo", equalTo("spice_orchid.jpg")).and()
+                .body("[1].description", equalTo("Spice Orchid is from the Orchid family.")).and()
+                .body("[1].category.name", equalTo("Orchid")).and()
+                .body("[1].category.photo", equalTo("orchid.jpg"));
+    }
+
+    @Test
+    public void whenGetPlantsByName_thenReturnEmptyList_andStatus200() {
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URL + port + "/floralfiesta/plant/name/Orchiddd")
+                .then().statusCode(200)
+                .body("size()", is(0));
+    }
+
+    @Test
+    public void whenGetPlantsByCategory_thenReturnPlants_andStatus200() {
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URL + port + "/floralfiesta/plant/category/" + plantCategory.getCategoryId())
+                .then().statusCode(200)
+                .body("size()", is(2)).and()
+                .body("[0].name", equalTo("Orchid")).and()
+                .body("[0].price", equalTo(12.0f)).and()
+                .body("[0].photo", equalTo("orchid.jpg")).and()
+                .body("[0].description", equalTo("Orchid is a plant that is very beautiful.")).and()
+                .body("[0].category.name", equalTo("Orchid")).and()
+                .body("[0].category.photo", equalTo("orchid.jpg")).and()
+                .body("[1].name", equalTo("Spice Orchid")).and()
+                .body("[1].price", equalTo(20.0f)).and()
+                .body("[1].photo", equalTo("spice_orchid.jpg")).and()
+                .body("[1].description", equalTo("Spice Orchid is from the Orchid family.")).and()
+                .body("[1].category.name", equalTo("Orchid")).and()
+                .body("[1].category.photo", equalTo("orchid.jpg"));
+    }
+
+    @Test
+    public void whenGetPlantsByCategory_thenReturnEmptyList_andStatus200() {
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URL + port + "/floralfiesta/plant/category/999")
+                .then().statusCode(200)
+                .body("size()", is(0));
+    }
+
+}

--- a/backend/src/test/java/tqs/estore/backend/serviceTests/CategoryService_UnitTest.java
+++ b/backend/src/test/java/tqs/estore/backend/serviceTests/CategoryService_UnitTest.java
@@ -1,0 +1,64 @@
+package tqs.estore.backend.serviceTests;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tqs.estore.backend.datamodel.PlantCategory;
+import tqs.estore.backend.repositories.CategoryRepository;
+import tqs.estore.backend.services.CategoryService;
+import java.util.List;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class CategoryService_UnitTest {
+    @Mock
+    private CategoryRepository categoryRepository;
+
+   @InjectMocks
+   private CategoryService categoryService;
+
+    private List<PlantCategory> categories;
+
+    @BeforeEach
+    public void setUp() {
+        PlantCategory plantCategory = new PlantCategory();
+        plantCategory.setCategoryId(1L);
+        plantCategory.setName("Orchid");
+        plantCategory.setPhoto("orchid.jpg");
+
+        PlantCategory plantCategory2 = new PlantCategory();
+        plantCategory2.setCategoryId(2L);
+        plantCategory2.setName("Tulip");
+        plantCategory2.setPhoto("tulip.jpg");
+
+        categories = List.of(plantCategory, plantCategory2);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        categories = null;
+    }
+
+    @Test
+    public void whenGetAllCategories_thenReturnCategories() {
+        when(categoryRepository.findAll()).thenReturn(categories);
+        List<PlantCategory> foundCategories = categoryService.getAllCategories();
+        assertThat(foundCategories).isEqualTo(categories);
+        verify(categoryRepository, times(1)).findAll();
+    }
+
+    @Test
+    public void whenGetAllCategories_thenReturnEmptyList() {
+        when(categoryRepository.findAll()).thenReturn(List.of());
+        List<PlantCategory> foundCategories = categoryService.getAllCategories();
+        assertThat(foundCategories).isEqualTo(List.of());
+        verify(categoryRepository, times(1)).findAll();
+    }
+
+}

--- a/backend/src/test/java/tqs/estore/backend/serviceTests/PlantService_UnitTest.java
+++ b/backend/src/test/java/tqs/estore/backend/serviceTests/PlantService_UnitTest.java
@@ -1,0 +1,143 @@
+package tqs.estore.backend.serviceTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tqs.estore.backend.datamodel.Plant;
+import tqs.estore.backend.datamodel.PlantCategory;
+import tqs.estore.backend.repositories.PlantRepository;
+import tqs.estore.backend.services.PlantService;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PlantService_UnitTest {
+    @Mock
+    private PlantRepository plantRepository;
+
+    @InjectMocks
+    private PlantService plantService;
+
+    private List<Plant> plants;
+    private List<Plant> plantsByName;
+
+    @BeforeEach
+    public void setUp() {
+        PlantCategory plantCategory = new PlantCategory();
+        plantCategory.setCategoryId(1L);
+        plantCategory.setName("Orchid");
+        plantCategory.setPhoto("orchid.jpg");
+
+        PlantCategory plantCategory2 = new PlantCategory();
+        plantCategory2.setCategoryId(2L);
+        plantCategory2.setName("Tulip");
+        plantCategory2.setPhoto("tulip.jpg");
+
+        plants = new ArrayList<>();
+        Plant plant1 = new Plant();
+        plant1.setName("Orchid");
+        plant1.setPrice(12.0);
+        plant1.setPhoto("orchid.jpg");
+        plant1.setDescription("Orchid is a plant that is very beautiful.");
+        plant1.setCategory(plantCategory);
+
+        Plant plant2 = new Plant();
+        plant2.setName("Tulip");
+        plant2.setPrice(5.0);
+        plant2.setPhoto("tulip.jpg");
+        plant2.setDescription("Tulip is a plant that makes people happy.");
+        plant2.setCategory(plantCategory2);
+
+        Plant plant3 = new Plant();
+        plant3.setName("Spice Orchid");
+        plant3.setPrice(20.0);
+        plant3.setPhoto("spice_orchid.jpg");
+        plant3.setDescription("Spice Orchid is from the Orchid family.");
+        plant3.setCategory(plantCategory);
+
+
+        plants.add(plant1);
+        plants.add(plant2);
+        plants.add(plant3);
+
+        plantsByName = new ArrayList<>();
+        plantsByName.add(plant1);
+        plantsByName.add(plant3);
+
+    }
+
+    @AfterEach
+    public void tearDown() {
+        plants = null;
+        plantsByName = null;
+    }
+
+    @Test
+    public void whenGetAllPlants_thenReturnPlants() {
+        when(plantRepository.findAll()).thenReturn(plants);
+
+        List<Plant> foundPlants = plantService.getAllPlants();
+
+        assertThat(foundPlants).isEqualTo(plants);
+        verify(plantRepository, times(1)).findAll();
+    }
+
+    @Test
+    public void whenGetAllPlants_thenReturnsEmptyList() {
+        when(plantRepository.findAll()).thenReturn(new ArrayList<>());
+
+        List<Plant> foundPlants = plantService.getAllPlants();
+
+        assertThat(foundPlants).isEqualTo(new ArrayList<>());
+        verify(plantRepository, times(1)).findAll();
+    }
+
+    @Test
+    public void whenGetPlantsByName_thenReturnPlants() {
+        when(plantRepository.findByNameContaining("Orchid")).thenReturn(plantsByName);
+
+        List<Plant> foundPlants = plantService.getPlantsByName("Orchid");
+
+        assertThat(foundPlants).isEqualTo(plantsByName);
+        verify(plantRepository, times(1)).findByNameContaining("Orchid");
+    }
+
+    @Test
+    public void whenGetPlantsByName_thenReturnsEmptyList() {
+        when(plantRepository.findByNameContaining("Tulip")).thenReturn(new ArrayList<>());
+
+        List<Plant> foundPlants = plantService.getPlantsByName("Tulip");
+
+        assertThat(foundPlants).isEqualTo(new ArrayList<>());
+        verify(plantRepository, times(1)).findByNameContaining("Tulip");
+    }
+
+    @Test
+    public void whenGetPlantsByCategory_thenReturnPlants() {
+        when(plantRepository.findByCategoryCategoryId(1L)).thenReturn(plantsByName);
+
+        List<Plant> foundPlants = plantService.getPlantsByCategory(1);
+
+        assertThat(foundPlants).isEqualTo(plantsByName);
+        verify(plantRepository, times(1)).findByCategoryCategoryId(1L);
+    }
+
+    @Test
+    public void whenGetPlantsByCategory_thenReturnsEmptyList() {
+        when(plantRepository.findByCategoryCategoryId(3L)).thenReturn(new ArrayList<>());
+
+        List<Plant> foundPlants = plantService.getPlantsByCategory(3);
+
+        assertThat(foundPlants).isEqualTo(new ArrayList<>());
+        verify(plantRepository, times(1)).findByCategoryCategoryId(3L);
+    }
+
+
+
+}


### PR DESCRIPTION
User Story: User Searches For Plants
Jira Code: DM-12

Changes made:

- Completed the getAllPlants, getPlantsByName and getPlantsByCategory on the Plant Controller and Plant Service
- Completed the getAllCategories on the Category Controller and Category Service
- Changed FetchType of plant's category attribute to Eager
- Changed getPlantsByCategory parameter to categoryID
- Added @PathVariable to every method of PlantController

Tests created:

- **Plant Controller Boundary Test**: Added the whenGetAllPlants_thenReturnPlants_andStatus200, whenGetAllPlants_thenReturnEmptyList_andStatus200, whenGetPlantsByName_thenReturnPlants_andStatus200, whenGetPlantsByName_thenReturnEmptyList_andStatus200, whenGetPlantsByCategory_thenReturnPlants_andStatus200, whenGetPlantsByCategory_thenReturnEmptyList_andStatus200 tests.
- **Plant Service Unit Test**: Added the whenGetAllPlants_thenReturnPlants, whenGetAllPlants_thenReturnsEmptyList, whenGetPlantsByName_thenReturnPlants, whenGetPlantsByName_thenReturnsEmptyList, whenGetPlantsByCategory_thenReturnPlants, whenGetPlantsByCategory_thenReturnsEmptyList tests.
- **Plant Controller Integration Test**: Added the whenGetAllPlants_thenReturnPlants_andStatus200, whenGetAllPlants_thenReturnEmptyList_andStatus200, whenGetPlantsByName_thenReturnPlants_andStatus200, whenGetPlantsByName_thenReturnEmptyList_andStatus200, whenGetPlantsByCategory_thenReturnPlants_andStatus200, whenGetPlantsByCategory_thenReturnEmptyList_andStatus200 tests.

- **Category Controller Boundary Test**: Added the whenGetAllCategories_thenReturnCategories_andStatus200 and whenGetAllCategories_thenReturnEmptyList_andStatus200 tests.
- **Category Service Unit Test**: Added the whenGetAllCategories_thenReturnCategories and whenGetAllCategories_thenReturnEmptyList tests.
- **Category Controller Integration Test**: Added the whenGetAllCategories_thenReturnCategories_andStatus200 and whenGetAllCategories_thenReturnEmptyList_andStatus200 tests.
